### PR TITLE
feat: add react v19 and react-router v7 in peerDependencies

### DIFF
--- a/DOCUMENTATION_V1.md
+++ b/DOCUMENTATION_V1.md
@@ -206,6 +206,7 @@ type OutletProps = {
 ✅ React 16  
 ✅ React 17  
 ✅ React 18
+✅ React 19
 
 If you face an issue with any version, open an issue.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,9 +70,10 @@
         "@storybook/manager-api": "^8.0.0",
         "@storybook/preview-api": "^8.0.0",
         "@storybook/theming": "^8.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-router-dom": "^6.4.0 || ^7.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-router-dom": "^6.4.0 || ^7.0.0",
+        "react-router": "^6.4.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "react": {

--- a/package.json
+++ b/package.json
@@ -72,9 +72,10 @@
     "@storybook/manager-api": "^8.0.0",
     "@storybook/preview-api": "^8.0.0",
     "@storybook/theming": "^8.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-router-dom": "^6.4.0 || ^7.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-router-dom": "^6.4.0 || ^7.0.0",
+    "react-router": "^6.4.0 || ^7.0.0"
   },
   "devDependencies": {
     "@auto-it/conventional-commits": "^11.3.0",


### PR DESCRIPTION
Add react and react-dom v19 and react-router v7 in project peerDependencies.

Fix https://github.com/JesusTheHun/storybook-addon-remix-react-router/issues/83 
https://github.com/JesusTheHun/storybook-addon-remix-react-router/issues/81

@JesusTheHun if you can review it :) 